### PR TITLE
Implemented MirrorNodeClientqueryTransaction

### DIFF
--- a/hedera-base/pom.xml
+++ b/hedera-base/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/TransactionInfo.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/TransactionInfo.java
@@ -1,11 +1,116 @@
 package com.openelements.hedera.base.mirrornode;
 
+import java.util.List;
 import java.util.Objects;
-import org.jspecify.annotations.NonNull;
 
-public record TransactionInfo(@NonNull String transactionId) {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 
-    public TransactionInfo {
+public record  TransactionInfo(    @Nullable Byte bytes,
+                                    long chargedTxFee,
+                                    String consensusTimestamp,
+                                    String entityId,
+                                    String maxFee,
+                                    String memoBase64,
+                                    String name,
+                                    List<NftTransfers>  nftTransfers,
+                                    String node,
+                                    int nonce,
+                                    String parentConsensusTimestamp,
+                                    String result,
+                                    boolean scheduled,
+                                    @Nullable List<Object> stakingRewardTransfers,
+                                    @Nullable List<Object> tokenTransfers,
+                                    String transactionHash,
+                                    String transactionId,
+                                    List<Transfers> transfers,
+                                    String validDurationSeconds,
+                                    String validStartTimestamp
+                        ) {
+
+    @JsonCreator
+    public TransactionInfo(
+            @JsonProperty("bytes") @Nullable Byte bytes,
+            @JsonProperty("charged_tx_fee") long chargedTxFee,
+            @JsonProperty("consensus_timestamp") String consensusTimestamp,
+            @JsonProperty("entity_id") String entityId,
+            @JsonProperty("max_fee") String maxFee,
+            @JsonProperty("memo_base64") String memoBase64,
+            @JsonProperty("name") String name,
+            @JsonProperty("nft_transfers") List<NftTransfers> nftTransfers,
+            @JsonProperty("node") String node,
+            @JsonProperty("nonce") int nonce,
+            @JsonProperty("parent_consensus_timestamp") String parentConsensusTimestamp,
+            @JsonProperty("result") String result,
+            @JsonProperty("scheduled") boolean scheduled,
+            @JsonProperty("staking_reward_transfers") @Nullable List<Object> stakingRewardTransfers,
+            @JsonProperty("token_transfers") @Nullable List<Object> tokenTransfers,
+            @JsonProperty("transaction_hash") String transactionHash,
+            @JsonProperty("transaction_id") String transactionId,
+            @JsonProperty("transfers") List<Transfers> transfers,
+            @JsonProperty("valid_duration_seconds") String validDurationSeconds,
+            @JsonProperty("valid_start_timestamp") String validStartTimestamp
+            ){
+                    this.bytes= bytes;
+                    this.chargedTxFee = chargedTxFee;
+                    this.consensusTimestamp= consensusTimestamp;
+                    this.entityId= entityId;
+                    this.maxFee= maxFee;
+                    this.memoBase64= memoBase64;
+                    this.name= name;
+                    this.nftTransfers= nftTransfers;
+                    this.node= node;
+                    this.nonce= nonce;
+                    this.parentConsensusTimestamp= parentConsensusTimestamp;
+                    this.result= result;
+                    this.scheduled= scheduled;
+                    this.stakingRewardTransfers= stakingRewardTransfers;
+                    this.tokenTransfers= tokenTransfers;
+                    this.transactionHash= transactionHash;
+                    this.transactionId= transactionId;
+                    this.transfers= transfers;
+                    this.validDurationSeconds= validDurationSeconds;
+                    this.validStartTimestamp= validStartTimestamp;
+
         Objects.requireNonNull(transactionId, "transactionId must not be null");
+    }
+}
+
+class NftTransfers{
+    private final boolean isApproval;
+    private final String receiverAccountId;
+    private final String senderAccountId;
+    private final int serialNumber;
+    private final String tokenId;
+
+    @JsonCreator
+    public NftTransfers(    @JsonProperty("is_approval") boolean isApproval,
+                            @JsonProperty("receiver_account_id") String receiverAccountId,
+                            @JsonProperty("sender_account_id") @Nullable String senderAccountId,
+                            @JsonProperty("serial_number") int serialNumber,
+                            @JsonProperty("token_id") String tokenId
+                        ) {
+        this.isApproval = isApproval;
+        this.receiverAccountId = receiverAccountId;
+        this.senderAccountId = senderAccountId;
+        this.serialNumber = serialNumber;
+        this.tokenId = tokenId;
+    }
+}
+
+class Transfers{
+    private final String account;
+    private final long amount;
+    private final boolean isApproved;
+
+    @JsonCreator
+    public Transfers(   @JsonProperty("account") String account,
+                        @JsonProperty("amount") long amount,
+                        @JsonProperty("is_approved") boolean isApproved
+                    ) {
+        this.account = account;
+        this.amount = amount;
+        this.isApproved = isApproved;
     }
 }

--- a/hedera-base/src/main/java/module-info.java
+++ b/hedera-base/src/main/java/module-info.java
@@ -7,4 +7,5 @@ module com.openelements.hedera.base {
     requires org.slf4j;
     requires com.google.protobuf; //TODO: We should not have the need to use it
     requires static org.jspecify;
+    requires com.fasterxml.jackson.annotation;
 }

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/MirrorNodeClientImpl.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/MirrorNodeClientImpl.java
@@ -92,10 +92,20 @@ public class MirrorNodeClientImpl implements MirrorNodeClient {
     public Optional<TransactionInfo> queryTransaction(@NonNull final String transactionId) throws HederaException {
         Objects.requireNonNull(transactionId, "transactionId must not be null");
         final JsonNode jsonNode = doGetCall("/api/v1/transactions/" + transactionId);
+        TransactionInfo transactionInfo = null;
+
         if (jsonNode == null || !jsonNode.fieldNames().hasNext()) {
             return Optional.empty();
         }
-        return Optional.of(new TransactionInfo(transactionId));
+        try {
+            transactionInfo = objectMapper.treeToValue(jsonNode, TransactionInfo.class);
+            return Optional.ofNullable( transactionInfo);
+        } catch (JsonProcessingException jsonProcessingException) {
+            System.err.println("Error while parsing data"+ jsonProcessingException.getMessage());
+            return Optional.empty();
+
+        }
+
     }
 
     private JsonNode doGetCall(String path, Map<String, ?> params) throws HederaException {


### PR DESCRIPTION
https://github.com/OpenElements/hedera-enterprise/issues/26

The **TransactionInfo** class was expanded to hold all the data that is indicated in the API call result as showed in the query sample of the issue with the corresponding data types.
Used the `@JsonCreator` and `@JsonProperty`to map exact field names to JSON key names.
The method `Optional<TransactionInfo> queryTransaction` in the **MirrorNodeClientImpl** class has been updated to use an object mapper to covert the JSON data to a `TransactionInfo` object finally return the `transactionInfo` object 