### PR TITLE
style: use proper modifier order

### DIFF
--- a/hedera-base/src/main/java/com/openelements/hedera/base/implementation/FileClientImpl.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/implementation/FileClientImpl.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class FileClientImpl implements FileClient {
 
-    private final static Logger log = LoggerFactory.getLogger(FileClientImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(FileClientImpl.class);
 
     private final ProtocolLayerClient protocolLayerClient;
 

--- a/hedera-base/src/main/java/com/openelements/hedera/base/implementation/ProtocolLayerClientImpl.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/implementation/ProtocolLayerClientImpl.java
@@ -89,7 +89,7 @@ import org.slf4j.LoggerFactory;
 
 public class ProtocolLayerClientImpl implements ProtocolLayerClient {
 
-    private final static Logger log = LoggerFactory.getLogger(ProtocolLayerClientImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(ProtocolLayerClientImpl.class);
 
     public static final int DEFAULT_GAS = 1_000_000;
 

--- a/hedera-base/src/main/java/com/openelements/hedera/base/implementation/SmartContractClientImpl.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/implementation/SmartContractClientImpl.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class SmartContractClientImpl implements SmartContractClient {
 
-    private final static Logger log = LoggerFactory.getLogger(SmartContractClientImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(SmartContractClientImpl.class);
 
     private final ProtocolLayerClient protocolLayerClient;
 

--- a/hedera-base/src/main/java/com/openelements/hedera/base/protocol/TokenMintRequest.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/protocol/TokenMintRequest.java
@@ -17,7 +17,7 @@ public record TokenMintRequest(@NonNull Hbar maxTransactionFee,
                                @Nullable Long amount,
                                @NonNull List<byte[]> metadata) implements TransactionRequest {
 
-    final static int MAX_METADATA_SIZE = 100;
+    static final int MAX_METADATA_SIZE = 100;
 
     public TokenMintRequest {
         Objects.requireNonNull(tokenId, "tokenId must not be null");

--- a/hedera-base/src/test/java/com/openelements/hedera/base/test/HederaTestContext.java
+++ b/hedera-base/src/test/java/com/openelements/hedera/base/test/HederaTestContext.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 public class HederaTestContext {
 
-    private final static Logger log = LoggerFactory.getLogger(HederaTestContext.class);
+    private static final Logger log = LoggerFactory.getLogger(HederaTestContext.class);
 
     private final Account operationalAccount;
 

--- a/hedera-microprofile/src/main/java/com/openelements/hedera/microprofile/implementation/ContractVerificationClientImpl.java
+++ b/hedera-microprofile/src/main/java/com/openelements/hedera/microprofile/implementation/ContractVerificationClientImpl.java
@@ -23,7 +23,7 @@ import org.jspecify.annotations.NonNull;
 
 public class ContractVerificationClientImpl implements ContractVerificationClient {
 
-    private final static String CONTRACT_VERIFICATION_URL = "https://server-verify.hashscan.io";
+    private static final String CONTRACT_VERIFICATION_URL = "https://server-verify.hashscan.io";
 
     private final HederaNetwork hederaNetwork;
 

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/ContractVerificationClientImplementation.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/ContractVerificationClientImplementation.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestClient;
 
 public class ContractVerificationClientImplementation implements ContractVerificationClient {
 
-    private final static String CONTRACT_VERIFICATION_URL = "https://server-verify.hashscan.io";
+    private static final String CONTRACT_VERIFICATION_URL = "https://server-verify.hashscan.io";
 
     private record VerifyRequest(String address, String chain, String creatorTxHash, String chosenContract,
                                  Map<String, String> files) {

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/ContractVerificationUtility.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/ContractVerificationUtility.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContractVerificationUtility {
 
-    private final static Logger log = LoggerFactory.getLogger(ContractVerificationUtility.class);
+    private static final Logger log = LoggerFactory.getLogger(ContractVerificationUtility.class);
 
     private final ContractVerificationClient verificationClient;
 

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.web.client.RestClient;
 @EnableConfigurationProperties({HederaProperties.class, HederaNetworkProperties.class})
 public class HederaAutoConfiguration {
 
-    private final static Logger log = LoggerFactory.getLogger(HederaAutoConfiguration.class);
+    private static final Logger log = LoggerFactory.getLogger(HederaAutoConfiguration.class);
 
     @Bean
     HederaNetwork hederaNetwork(final HederaProperties properties) {

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/RestBasedPage.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/RestBasedPage.java
@@ -19,7 +19,7 @@ import org.springframework.web.client.RestClient;
 
 public class RestBasedPage<T> implements Page<T> {
 
-    private final static Logger log = LoggerFactory.getLogger(RestBasedPage.class);
+    private static final Logger log = LoggerFactory.getLogger(RestBasedPage.class);
 
 
     private final ObjectMapper objectMapper;


### PR DESCRIPTION
This PR changes the order of `final` and `static` modifiers, to be consistent with the remaining part of this repository and with the [recommended ordering](https://checkstyle.sourceforge.io/checks/modifier/modifierorder.html).

After this change, checkstyle does not report more `ModifierOrder` warnings.

@hendrikebbers: please approve the workflow run.