### PR TITLE
chore: setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+...


### PR DESCRIPTION
This PR setups dependabot to keep github-actions up-todate.

Fixes #42.