### PR TITLE
#46 Add constructor tests for TopicDeleteResult

### DIFF
--- a/hedera-base/src/test/java/com/openelements/hedera/base/test/ProtocolLayerDataCreationTests.java
+++ b/hedera-base/src/test/java/com/openelements/hedera/base/test/ProtocolLayerDataCreationTests.java
@@ -27,6 +27,7 @@ import com.openelements.hedera.base.protocol.ContractDeleteRequest;
 import com.openelements.hedera.base.protocol.ContractDeleteResult;
 import com.openelements.hedera.base.protocol.FileAppendRequest;
 import com.openelements.hedera.base.protocol.TokenTransferResult;
+import com.openelements.hedera.base.protocol.TopicDeleteResult;
 import com.openelements.hedera.base.protocol.TokenMintResult;
 import com.openelements.hedera.base.protocol.TokenCreateResult;
 import com.openelements.hedera.base.protocol.TokenBurnResult;
@@ -726,5 +727,18 @@ public class ProtocolLayerDataCreationTests {
         Assertions.assertDoesNotThrow(() -> new TopicSubmitMessageResult(validTransactionId, validStatus));
         Assertions.assertThrows(NullPointerException.class, () -> new TopicSubmitMessageResult(null, validStatus));
         Assertions.assertThrows(NullPointerException.class, () -> new TopicSubmitMessageResult(validTransactionId, null));
+    }
+    
+    @Test
+    void testTopicDeleteResult() {
+    	
+    	//given
+    	final TransactionId validTransactionId = TransactionId.fromString("0.0.123451@1697590800.123456789");
+    	final Status validStatus =Status.SUCCESS;
+    	
+    	//then
+    	Assertions.assertDoesNotThrow(() -> new TopicDeleteResult(validTransactionId,validStatus));
+    	Assertions.assertThrows(NullPointerException.class, () -> new TopicDeleteResult(null, validStatus));
+    	Assertions.assertThrows(NullPointerException.class, () -> new TopicDeleteResult(validTransactionId, null));
     }
 }

--- a/hedera-base/src/test/java/com/openelements/hedera/base/test/ProtocolLayerDataCreationTests.java
+++ b/hedera-base/src/test/java/com/openelements/hedera/base/test/ProtocolLayerDataCreationTests.java
@@ -730,8 +730,7 @@ public class ProtocolLayerDataCreationTests {
     }
     
     @Test
-    void testTopicDeleteResult() {
-    	
+    void testTopicDeleteResultCreation() {
     	//given
     	final TransactionId validTransactionId = TransactionId.fromString("0.0.123451@1697590800.123456789");
     	final Status validStatus =Status.SUCCESS;


### PR DESCRIPTION
### Fixed Issue #46 

### Summary
Constructor tests for the TopicDeleteResult was added in the ProtocolLayerDataCreationTests class
A new test method i.e testTopicDeleteResult was added in the ProtocolLayerDataCreationTests class that implements all the needed tests for the TopicDeleteResult.

