### PR TITLE
feat: Implement AccountsRepository to interact with Mirror Node REST API

### DIFF
--- a/hedera-base/src/main/java/com/openelements/hedera/base/AccountRepository.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/AccountRepository.java
@@ -1,0 +1,34 @@
+package com.openelements.hedera.base;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.openelements.hedera.base.mirrornode.AccountInfo;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Interface for interacting with a Hedera network. This interface provides methods for searching for Accounts.
+ */
+public interface AccountRepository {
+    /**
+     * Return the AccountInfo of a given accountId.
+     *
+     * @param accountId  id of the account
+     * @return {@link Optional} containing the found AccountInfo or null
+     * @throws HederaException if the search fails
+     */
+    Optional<AccountInfo> findById(@NonNull AccountId accountId) throws HederaException;
+
+    /**
+     * Return the AccountInfo of a given accountId.
+     *
+     * @param accountId  id of the account
+     * @return {@link Optional} containing the found AccountInfo or null
+     * @throws HederaException if the search fails
+     */
+    default Optional<AccountInfo> findById(@NonNull String accountId) throws HederaException {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        return findById(AccountId.fromString(accountId));
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/implementation/AccountRepositoryImpl.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/implementation/AccountRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.openelements.hedera.base.implementation;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.openelements.hedera.base.AccountRepository;
+import com.openelements.hedera.base.HederaException;
+import com.openelements.hedera.base.mirrornode.AccountInfo;
+import com.openelements.hedera.base.mirrornode.MirrorNodeClient;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class AccountRepositoryImpl implements AccountRepository {
+    private final MirrorNodeClient mirrorNodeClient;
+
+    public AccountRepositoryImpl(@NonNull final MirrorNodeClient mirrorNodeClient) {
+        this.mirrorNodeClient = Objects.requireNonNull(mirrorNodeClient, "mirrorNodeClient must not be null");
+    }
+
+    @Override
+    public Optional<AccountInfo> findById(@NonNull AccountId accountId) throws HederaException {
+        return mirrorNodeClient.queryAccount(accountId);
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/AccountInfo.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/AccountInfo.java
@@ -1,0 +1,14 @@
+package com.openelements.hedera.base.mirrornode;
+
+import com.hedera.hashgraph.sdk.AccountBalance;
+import com.hedera.hashgraph.sdk.AccountId;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record AccountInfo(@NonNull AccountId accountId, @NonNull String evmAddress, long balance, long ethereumNonce, long pendingReward) {
+    public AccountInfo {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(evmAddress, "evmAddress must not be null");
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/MirrorNodeClient.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/MirrorNodeClient.java
@@ -153,4 +153,27 @@ public interface MirrorNodeClient {
      */
     @NonNull
     Optional<TransactionInfo> queryTransaction(@NonNull String transactionId) throws HederaException;
+
+    /**
+     * Queries the account information for a specific account ID.
+     *
+     * @param accountId the account ID
+     * @return the account information for the account ID
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    Optional<AccountInfo> queryAccount(@NonNull AccountId accountId) throws HederaException;
+
+    /**
+     * Queries the account information for a specific account ID.
+     *
+     * @param accountId the account ID
+     * @return the account information for the account ID
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    default Optional<AccountInfo> queryAccount(@NonNull String accountId) throws HederaException {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        return queryAccount(AccountId.fromString(accountId));
+    }
 }

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
@@ -9,6 +9,7 @@ import com.openelements.hedera.base.ContractVerificationClient;
 import com.openelements.hedera.base.FileClient;
 import com.openelements.hedera.base.NftClient;
 import com.openelements.hedera.base.NftRepository;
+import com.openelements.hedera.base.AccountRepository;
 import com.openelements.hedera.base.SmartContractClient;
 import com.openelements.hedera.base.implementation.AccountClientImpl;
 import com.openelements.hedera.base.implementation.FileClientImpl;
@@ -17,6 +18,7 @@ import com.openelements.hedera.base.implementation.NftClientImpl;
 import com.openelements.hedera.base.implementation.NftRepositoryImpl;
 import com.openelements.hedera.base.implementation.ProtocolLayerClientImpl;
 import com.openelements.hedera.base.implementation.SmartContractClientImpl;
+import com.openelements.hedera.base.implementation.AccountRepositoryImpl;
 import com.openelements.hedera.base.mirrornode.MirrorNodeClient;
 import com.openelements.hedera.base.protocol.ProtocolLayerClient;
 import java.net.URI;
@@ -198,6 +200,13 @@ public class HederaAutoConfiguration {
             havingValue = "true", matchIfMissing = true)
     NftRepository nftRepository(final MirrorNodeClient mirrorNodeClient) {
         return new NftRepositoryImpl(mirrorNodeClient);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.hedera", name = "mirrorNodeSupported",
+            havingValue = "true", matchIfMissing = true)
+    AccountRepository accountRepository(final MirrorNodeClient mirrorNodeClient) {
+        return new AccountRepositoryImpl(mirrorNodeClient);
     }
 
     @Bean

--- a/hedera-spring/src/test/java/com/openelements/hedera/spring/test/AccountRepositoryTest.java
+++ b/hedera-spring/src/test/java/com/openelements/hedera/spring/test/AccountRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.openelements.hedera.spring.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.openelements.hedera.base.Account;
+import com.openelements.hedera.base.AccountClient;
+import com.openelements.hedera.base.AccountRepository;
+import com.openelements.hedera.base.mirrornode.AccountInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+@SpringBootTest(classes = TestConfig.class)
+public class AccountRepositoryTest {
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private HederaTestUtils hederaTestUtils;
+
+    @Autowired
+    private AccountClient accountClient;
+
+    @Test
+    void findById() throws Exception {
+        //given
+        final Account account = accountClient.createAccount();
+        final AccountId newOwner = account.accountId();
+        hederaTestUtils.waitForMirrorNodeRecords();
+
+        //when
+        final Optional<AccountInfo> result = accountRepository.findById(newOwner);
+
+        //then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+    }
+}


### PR DESCRIPTION
This PR introduces the  `AccountRepository` interface and its implementation to interact with the Mirror Node REST API.

Closes #36 