### PR TITLE
feat: Implement NetworkRepository to interact with Mirror Node REST API

### DIFF
--- a/hedera-base/src/main/java/com/openelements/hedera/base/NetworkRepository.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/NetworkRepository.java
@@ -1,0 +1,46 @@
+package com.openelements.hedera.base;
+
+import com.openelements.hedera.base.mirrornode.ExchangeRates;
+import com.openelements.hedera.base.mirrornode.NetworkFee;
+import com.openelements.hedera.base.mirrornode.NetworkStake;
+import com.openelements.hedera.base.mirrornode.NetworkSupplies;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for interacting with a Hedera network. This interface provides methods to get information related to Network.
+ */
+public interface NetworkRepository {
+    /**
+     * Return the ExchangeRates for network.
+     *
+     * @return {@link Optional} containing the ExchangeRates or null
+     * @throws HederaException if the search fails
+     */
+    Optional<ExchangeRates> exchangeRates() throws HederaException;
+
+    /**
+     * Return the List of NetworkFee for network.
+     *
+     * @return {@link List} containing NetworkFee or empty list
+     * @throws HederaException if the search fails
+     */
+    List<NetworkFee> fees() throws HederaException;
+
+    /**
+     * Return the NetworkStake for network.
+     *
+     * @return {@link Optional} containing NetworkStake or null
+     * @throws HederaException if the search fails
+     */
+    Optional<NetworkStake> stake() throws HederaException;
+
+    /**
+     * Return the NetworkSupplies for network.
+     *
+     * @return {@link Optional} containing NetworkSupplies or null
+     * @throws HederaException if the search fails
+     */
+    Optional<NetworkSupplies> supplies() throws HederaException;
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/implementation/NetworkRepositoryImpl.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/implementation/NetworkRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.openelements.hedera.base.implementation;
+
+import com.openelements.hedera.base.HederaException;
+import com.openelements.hedera.base.NetworkRepository;
+import com.openelements.hedera.base.mirrornode.ExchangeRates;
+import com.openelements.hedera.base.mirrornode.MirrorNodeClient;
+import com.openelements.hedera.base.mirrornode.NetworkFee;
+import com.openelements.hedera.base.mirrornode.NetworkStake;
+import com.openelements.hedera.base.mirrornode.NetworkSupplies;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class NetworkRepositoryImpl implements NetworkRepository {
+    private final MirrorNodeClient mirrorNodeClient;
+
+    public NetworkRepositoryImpl(@NonNull final MirrorNodeClient mirrorNodeClient) {
+        this.mirrorNodeClient = Objects.requireNonNull(mirrorNodeClient, "mirrorNodeClient must not be null");
+    }
+
+    @Override
+    public Optional<ExchangeRates> exchangeRates() throws HederaException {
+        return mirrorNodeClient.queryExchangeRates();
+    }
+
+    @Override
+    public List<NetworkFee> fees() throws HederaException {
+        return mirrorNodeClient.queryNetworkFees();
+    }
+
+    @Override
+    public Optional<NetworkStake> stake() throws HederaException {
+        return mirrorNodeClient.queryNetworkStake();
+    }
+
+    @Override
+    public Optional<NetworkSupplies> supplies() throws HederaException {
+        return mirrorNodeClient.queryNetworkSupplies();
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/ExchangeRate.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/ExchangeRate.java
@@ -1,0 +1,12 @@
+package com.openelements.hedera.base.mirrornode;
+
+import org.jspecify.annotations.NonNull;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ExchangeRate(int centEquivalent, int hbarEquivalent, @NonNull  Instant expirationTime) {
+    public ExchangeRate {
+        Objects.requireNonNull(expirationTime, "expirationTime must not be null");
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/ExchangeRates.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/ExchangeRates.java
@@ -1,0 +1,12 @@
+package com.openelements.hedera.base.mirrornode;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record ExchangeRates(@NonNull  ExchangeRate currentRate, @NonNull  ExchangeRate nextRate) {
+    public ExchangeRates {
+        Objects.requireNonNull(currentRate, "currentRate must not be null");
+        Objects.requireNonNull(nextRate, "nextRate must not be null");
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/MirrorNodeClient.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/MirrorNodeClient.java
@@ -1,5 +1,6 @@
 package com.openelements.hedera.base.mirrornode;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -189,4 +190,40 @@ public interface MirrorNodeClient {
         Objects.requireNonNull(accountId, "accountId must not be null");
         return queryAccount(AccountId.fromString(accountId));
     }
+
+    /**
+     * Queries the ExchangeRates for the network.
+     *
+     * @return the Optional of ExchangeRates for the Network
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    Optional<ExchangeRates> queryExchangeRates() throws HederaException;
+
+    /**
+     * Queries the NetworkFee for the network.
+     *
+     * @return the List of NetworkFee for the Network
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    List<NetworkFee> queryNetworkFees() throws HederaException;
+
+    /**
+     * Queries the NetworkStake for the network.
+     *
+     * @return the Optional of NetworkStake for the Network
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    Optional<NetworkStake> queryNetworkStake() throws HederaException;
+
+    /**
+     * Queries the NetworkSupplies for the network.
+     *
+     * @return the Optional of NetworkSupplies for the Network
+     * @throws HederaException if an error occurs
+     */
+    @NonNull
+    Optional<NetworkSupplies> queryNetworkSupplies() throws HederaException;
 }

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkFee.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkFee.java
@@ -1,0 +1,11 @@
+package com.openelements.hedera.base.mirrornode;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record NetworkFee(long gas, @NonNull String transactionType) {
+    public NetworkFee {
+        Objects.requireNonNull(transactionType, "transactionType must not be null");
+    }
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkStake.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkStake.java
@@ -1,0 +1,19 @@
+package com.openelements.hedera.base.mirrornode;
+
+public record NetworkStake(
+        long maxStakeReward,
+        long maxStakeRewardPerHbar,
+        long maxTotalReward,
+        double nodeRewardFeeFraction,
+        long reservedStakingRewards,
+        long rewardBalanceThreshold,
+        long stakeTotal,
+        long stakingPeriodDuration,
+        long stakingPeriodsStored,
+        double stakingRewardFeeFraction,
+        long stakingRewardRate,
+        long stakingStartThreshold,
+        long unreservedStakingRewardBalance
+) {
+    public NetworkStake {}
+}

--- a/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkSupplies.java
+++ b/hedera-base/src/main/java/com/openelements/hedera/base/mirrornode/NetworkSupplies.java
@@ -1,0 +1,12 @@
+package com.openelements.hedera.base.mirrornode;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record NetworkSupplies(@NonNull String releasedSupply, @NonNull String totalSupply) {
+    public NetworkSupplies {
+        Objects.requireNonNull(releasedSupply, "releasedSupply must not be null");
+        Objects.requireNonNull(totalSupply, "totalSupply must not be null");
+    }
+}

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/HederaAutoConfiguration.java
@@ -10,6 +10,7 @@ import com.openelements.hedera.base.FileClient;
 import com.openelements.hedera.base.NftClient;
 import com.openelements.hedera.base.NftRepository;
 import com.openelements.hedera.base.AccountRepository;
+import com.openelements.hedera.base.NetworkRepository;
 import com.openelements.hedera.base.SmartContractClient;
 import com.openelements.hedera.base.implementation.AccountClientImpl;
 import com.openelements.hedera.base.implementation.FileClientImpl;
@@ -19,6 +20,7 @@ import com.openelements.hedera.base.implementation.NftRepositoryImpl;
 import com.openelements.hedera.base.implementation.ProtocolLayerClientImpl;
 import com.openelements.hedera.base.implementation.SmartContractClientImpl;
 import com.openelements.hedera.base.implementation.AccountRepositoryImpl;
+import com.openelements.hedera.base.implementation.NetworkRepositoryImpl;
 import com.openelements.hedera.base.mirrornode.MirrorNodeClient;
 import com.openelements.hedera.base.protocol.ProtocolLayerClient;
 import java.net.URI;
@@ -207,6 +209,13 @@ public class HederaAutoConfiguration {
             havingValue = "true", matchIfMissing = true)
     AccountRepository accountRepository(final MirrorNodeClient mirrorNodeClient) {
         return new AccountRepositoryImpl(mirrorNodeClient);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.hedera", name = "mirrorNodeSupported",
+            havingValue = "true", matchIfMissing = true)
+    NetworkRepository networkRepository(final MirrorNodeClient mirrorNodeClient) {
+        return new NetworkRepositoryImpl(mirrorNodeClient);
     }
 
     @Bean

--- a/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/MirrorNodeClientImpl.java
+++ b/hedera-spring/src/main/java/com/openelements/hedera/spring/implementation/MirrorNodeClientImpl.java
@@ -2,6 +2,7 @@ package com.openelements.hedera.spring.implementation;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,6 +31,11 @@ import com.openelements.hedera.base.mirrornode.AccountInfo;
 import com.openelements.hedera.base.mirrornode.MirrorNodeClient;
 import com.openelements.hedera.base.mirrornode.Page;
 import com.openelements.hedera.base.mirrornode.TransactionInfo;
+import com.openelements.hedera.base.mirrornode.ExchangeRate;
+import com.openelements.hedera.base.mirrornode.ExchangeRates;
+import com.openelements.hedera.base.mirrornode.NetworkFee;
+import com.openelements.hedera.base.mirrornode.NetworkStake;
+import com.openelements.hedera.base.mirrornode.NetworkSupplies;
 
 public class MirrorNodeClientImpl implements MirrorNodeClient {
 
@@ -114,6 +120,30 @@ public class MirrorNodeClientImpl implements MirrorNodeClient {
         Objects.requireNonNull(accountId, "accountId must not be null");
         final JsonNode jsonNode = doGetCall("/api/v1/accounts/" + accountId);
         return jsonNodeToOptionalAccountINfo(jsonNode);
+    }
+
+    @Override
+    public @NonNull Optional<ExchangeRates> queryExchangeRates() throws HederaException {
+        final JsonNode jsonNode = doGetCall("/api/v1/network/exchangerate");
+        return jsonNodeToOptionalExchangeRates(jsonNode);
+    }
+
+    @Override
+    public @NonNull List<NetworkFee> queryNetworkFees() throws HederaException {
+        final JsonNode jsonNode = doGetCall("/api/v1/network/fees");
+        return jsonNodeToListNetworkFee(jsonNode);
+    }
+
+    @Override
+    public @NonNull Optional<NetworkStake> queryNetworkStake() throws HederaException {
+        final JsonNode jsonNode = doGetCall("/api/v1/network/stake");
+        return jsonNodeToOptionalNetworkStake(jsonNode);
+    }
+
+    @Override
+    public @NonNull Optional<NetworkSupplies> queryNetworkSupplies() throws HederaException {
+        final JsonNode jsonNode = doGetCall("/api/v1/network/supply");
+        return jsonNodeToOptionalNetworkSupplies(jsonNode);
     }
 
     private JsonNode doGetCall(String path, Map<String, ?> params) throws HederaException {
@@ -211,6 +241,140 @@ public class MirrorNodeClientImpl implements MirrorNodeClient {
             return new AccountInfo(accountId, evmAddress, balance, ethereumNonce, pendingReward);
         } catch (final Exception e) {
             throw new IllegalArgumentException("Error parsing NFT from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private @NonNull Optional<ExchangeRates> jsonNodeToOptionalExchangeRates(JsonNode jsonNode) throws HederaException {
+        if (jsonNode == null || !jsonNode.fieldNames().hasNext()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(jsonNodeToExchangeRates(jsonNode));
+        } catch (final Exception e) {
+            throw new HederaException("Error parsing ExchangeRates from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private ExchangeRates jsonNodeToExchangeRates(JsonNode jsonNode) {
+        try {
+            final int currentCentEquivalent = jsonNode.get("current_rate").get("cent_equivalent").asInt();
+            final int currentHbarEquivalent = jsonNode.get("current_rate").get("hbar_equivalent").asInt();
+            final Instant currentExpirationTime = Instant.ofEpochSecond(
+                    jsonNode.get("current_rate").get("expiration_time").asLong()
+            );
+
+            final int nextCentEquivalent = jsonNode.get("next_rate").get("cent_equivalent").asInt();
+            final int nextHbarEquivalent = jsonNode.get("next_rate").get("hbar_equivalent").asInt();
+            final Instant nextExpirationTime = Instant.ofEpochSecond(
+                    jsonNode.get("next_rate").get("expiration_time").asLong()
+            );
+
+            return new ExchangeRates(
+                    new ExchangeRate(currentCentEquivalent, currentHbarEquivalent, currentExpirationTime),
+                    new ExchangeRate(nextCentEquivalent, nextHbarEquivalent, nextExpirationTime)
+            );
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Error parsing ExchangeRates from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private List<NetworkFee> jsonNodeToListNetworkFee(JsonNode jsonNode) throws HederaException {
+        if(jsonNode == null || !jsonNode.fieldNames().hasNext() || !jsonNode.has("fees")) {
+            return List.of();
+        }
+
+        final JsonNode feesNode = jsonNode.get("fees");
+        if (!feesNode.isArray()) {
+            throw new IllegalArgumentException("Fees node is not an array: " + feesNode);
+        }
+
+        try {
+            return StreamSupport
+                    .stream(Spliterators.spliteratorUnknownSize(feesNode.iterator(), Spliterator.ORDERED), false)
+                    .map(this::jsonNodeToNetworkFee)
+                    .toList();
+        } catch (final Exception e) {
+            throw new HederaException("Error parsing NetworkFees from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private NetworkFee jsonNodeToNetworkFee(JsonNode jsonNode) {
+        try {
+            final long gas = jsonNode.get("gas").asLong();
+            final String transactionType = jsonNode.get("transaction_type").asText();
+
+            return new NetworkFee(gas, transactionType);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Error parsing NetworkFee from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private @NonNull Optional<NetworkStake> jsonNodeToOptionalNetworkStake(JsonNode jsonNode) throws HederaException {
+        if (jsonNode == null || !jsonNode.fieldNames().hasNext()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(jsonNodeToNetworkStake(jsonNode));
+        } catch (final Exception e) {
+            throw new HederaException("Error parsing NetworkStake from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private NetworkStake jsonNodeToNetworkStake(JsonNode jsonNode) {
+        try {
+            final long maxStakeReward = jsonNode.get("max_stake_rewarded").asLong();
+            final long maxStakeRewardPerHbar = jsonNode.get("max_staking_reward_rate_per_hbar").asLong();
+            final long maxTotalReward = jsonNode.get("max_total_reward").asLong();
+            final double nodeRewardFeeFraction = jsonNode.get("node_reward_fee_fraction").asDouble();
+            final long reservedStakingRewards = jsonNode.get("reserved_staking_rewards").asLong();
+            final long rewardBalanceThreshold = jsonNode.get("reward_balance_threshold").asLong();
+            final long stakeTotal = jsonNode.get("stake_total").asLong();
+            final long stakingPeriodDuration = jsonNode.get("staking_period_duration").asLong();
+            final long stakingPeriodsStored = jsonNode.get("staking_periods_stored").asLong();
+            final double stakingRewardFeeFraction = jsonNode.get("staking_reward_fee_fraction").asDouble();
+            final long stakingRewardRate = jsonNode.get("staking_reward_rate").asLong();
+            final long stakingStartThreshold = jsonNode.get("staking_start_threshold").asLong();
+            final long unreservedStakingRewardBalance = jsonNode.get("unreserved_staking_reward_balance").asLong();
+
+            return new NetworkStake(
+                    maxStakeReward,
+                    maxStakeRewardPerHbar,
+                    maxTotalReward,
+                    nodeRewardFeeFraction,
+                    reservedStakingRewards,
+                    rewardBalanceThreshold,
+                    stakeTotal,
+                    stakingPeriodDuration,
+                    stakingPeriodsStored,
+                    stakingRewardFeeFraction,
+                    stakingRewardRate,
+                    stakingStartThreshold,
+                    unreservedStakingRewardBalance
+            );
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Error parsing NetworkStake from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private @NonNull Optional<NetworkSupplies> jsonNodeToOptionalNetworkSupplies(JsonNode jsonNode) throws HederaException {
+        if (jsonNode == null || !jsonNode.fieldNames().hasNext()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(jsonNodeToNetworkSupplies(jsonNode));
+        } catch (final Exception e) {
+            throw new HederaException("Error parsing NetworkSupplies from JSON '" + jsonNode + "'", e);
+        }
+    }
+
+    private NetworkSupplies jsonNodeToNetworkSupplies(JsonNode jsonNode) {
+        try {
+            final String releasedSupply = jsonNode.get("released_supply").asText();
+            final String totalSupply = jsonNode.get("total_supply").asText();
+
+            return new NetworkSupplies(releasedSupply, totalSupply);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Error parsing NetworkSupplies from JSON '" + jsonNode + "'", e);
         }
     }
 

--- a/hedera-spring/src/test/java/com/openelements/hedera/spring/test/NetworkRepositoryTest.java
+++ b/hedera-spring/src/test/java/com/openelements/hedera/spring/test/NetworkRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.openelements.hedera.spring.test;
+
+import com.openelements.hedera.base.HederaException;
+import com.openelements.hedera.base.NetworkRepository;
+import com.openelements.hedera.base.mirrornode.ExchangeRates;
+import com.openelements.hedera.base.mirrornode.NetworkFee;
+import com.openelements.hedera.base.mirrornode.NetworkStake;
+import com.openelements.hedera.base.mirrornode.NetworkSupplies;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest(classes = TestConfig.class)
+public class NetworkRepositoryTest {
+    @Autowired
+    private NetworkRepository networkRepository;
+
+    @Test
+    void findExchangeRates() throws HederaException {
+        Optional<ExchangeRates> result = networkRepository.exchangeRates();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+    }
+
+    @Test
+    void findNetworkFees() throws HederaException {
+        List<NetworkFee> result = networkRepository.fees();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void findNetworkStake() throws HederaException {
+        Optional<NetworkStake> result = networkRepository.stake();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+    }
+
+    @Test
+    void findNetworkSupplies() throws HederaException {
+        Optional<NetworkSupplies> result = networkRepository.supplies();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+    }
+}


### PR DESCRIPTION
This PR introduces the `NetworkRepository` interface and its implementation to interact with the Mirror Node REST API to query network related information.

Closes: #38 